### PR TITLE
Fix bugs in transition animation

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -3,6 +3,10 @@ disableToTop = false
 enableSearch = true
 enableHighlight = true
 
+# There's a transition animation in the background when you turn on dark mode.
+# default is true
+enableDarkAnimate = true
+
 [app]
   # optional site title override for the app when added to an iOS home screen or Android launcher
   title = "Seven Demo"
@@ -19,10 +23,6 @@ enableHighlight = true
   enable = true
   lightImg = "/images/bg.svg"
   darkImg = "/images/bg-dark.svg"
-
-  # There's a transition animation in the background when you turn on dark mode.
-  # default is true
-  enableBgAnimate = true
 
 [logo]
   # Image logo or Text logo

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -41,58 +41,57 @@
   </head>
 
   <body
-    x-cloak
+    x-ref="body"
     x-data="{ 
       shrink: false,
-      enableBgAni: {{ .Site.Params.background.enableBgAnimate | default true }},
       scrollY: 0,
       bgOpen: {{ .Site.Params.background.enable }},
-      darkImg: '{{ .Site.Params.background.darkImg }}',
-      lightImg: '{{ .Site.Params.background.lightImg }}',
-      newbgImg: '',
-      bgImg: '',
-
-      init() {
-        if (this.bgOpen && $store.darkMode.on) {
-          bgImg = this.darkImg
-        } else if (this.bgOpen && !$store.darkMode.on) {
-          bgImg = this.lightImg
-        } else {
-          bgImg = ''
-        }
-      },
-
-      get bgImg () {
-        return bgImg
-      },
-
-      set bgImg(v) {
-        bgImg = v;
-      },
-
-      getNewBgImg() {
-        return bgImg;
-      },
     }"
-    x-init="$watch('$store.darkMode.on', (value) => {
-      if (value && bgOpen) {
-        bgImg = '{{ .Site.Params.background.darkImg }}'
-      } else if (!value && bgOpen) {
-        bgImg = '{{ .Site.Params.background.lightImg }}'
-      } 
-    })"
-    @click="newbgImg = getNewBgImg()"
     @scroll.window="shrink = (window.scrollY > 10 ? true : false)"
-    x-effect="$el.style.backgroundImage = 'url(' + bgImg + ')'"
-    :style="'background-image: ' + 'url(' + newbgImg + ')'"
-    :class="{'bg-white': !bgOpen, 'dark:bg-gray-900': !bgOpen, 'bg-cover': bgOpen, 'bg-fixed': bgOpen, 'dark:delay-300': enableBgAni }"
-    class="flex h-screen flex-col scroll-auto">
+    :style="'background-image: ' + 'url(' + $store.bgImg.bgImg + ')'"
+    :class="{'bg-white': !bgOpen, 'dark:bg-gray-900': !bgOpen, 'bg-cover': bgOpen, 'bg-fixed': bgOpen, 'dark:delay-300': $store.darkMode.animate}"
+    class="-z-10 flex h-screen flex-col scroll-auto">
+    <!-- 默认为白天模式，点击🌛，白转黑 -->
+    <!-- toDarkAnimate: true -> 白转黑 -->
+    <!-- toDarkAnimate: false -> 黑转白 -->
     <div
-      x-show="$store.darkMode.on && enableBgAni"
+      x-show="$store.darkMode.toDarkAnimate"
       x-cloak
       x-transition:enter="animate-bgScaleInTr"
       x-transition:leave="animate-bgScaleOutTr"
-      :style="'background-image: ' + 'url(' + darkImg + ')'"
+      :style="'background-image: ' + 'url(' + $store.bgImg.dark + ')'"
+      :class="{'bg-gray-900': !bgOpen,'dark:bg-gray-900': !bgOpen, 'bg-cover': bgOpen, 'bg-fixed': bgOpen}"
+      class="fixed left-0 top-0 -z-10 h-full w-full"></div>
+    <!-- 默认为黑夜模式，点击🌞，黑转白 -->
+    <!-- toLightAnimate: true -> 黑转白 -->
+    <!-- toLightAnimate: false -> 白转黑 -->
+    <div
+      x-show="$store.darkMode.toLightAnimate"
+      x-cloak
+      x-transition:enter="animate-bgScaleOutTr"
+      x-transition:leave="animate-bgScaleInTr"
+      x-init="$watch(
+        '$store.darkMode.toLightAnimate', (value) => {
+          if (bgOpen) {
+            $el.style.backgroundImage = 'url(' + $store.bgImg.dark + ')'
+            if (value) {
+              setTimeout(() => {
+                $el.style.backgroundImage = 'url(' + $store.bgImg.light + ')'
+              }, 300)
+            } 
+          } else {
+            $el.classList.remove('bg-white');
+            $el.classList.add('bg-gray-900')
+            if (value) {
+              setTimeout(()=>{
+                $el.classList.remove('bg-gray-900');
+                $el.classList.add('bg-white')
+              }, 300)
+            } 
+          }
+        }
+      )"
+      :style="'background-image: ' + 'url(' + $store.bgImg.dark + ')'"
       :class="{'bg-gray-900': !bgOpen,'dark:bg-gray-900': !bgOpen, 'bg-cover': bgOpen, 'bg-fixed': bgOpen}"
       class="fixed left-0 top-0 -z-10 h-full w-full"></div>
 

--- a/layouts/partials/head/script.html
+++ b/layouts/partials/head/script.html
@@ -18,14 +18,30 @@
     document.documentElement.classList.remove("dark");
   }
 
+  if ("{{ .Site.Params.background.enable }}" === 'true') {
+    console.log('bg img enable')
+    let _lightbg = new Image();
+    let _darkbg = new Image();
+    _lightbg.src = "{{ .Site.Params.background.lightImg }}";
+    _darkbg.src = "{{ .Site.Params.background.darkImg }}";
+  }
+
   document.addEventListener("alpine:init", () => {
     Alpine.store("darkMode", {
-      on:
-        localStorage.getItem("color-theme") === "dark" ||
-        (!("color-theme" in localStorage) &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches),
+      on: localStorage.getItem("color-theme") === "dark" || (!("color-theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches),
+      animate: '{{ .Site.Params.enableDarkAnimate | default true }}' === 'true',
+
+      initDark: localStorage.getItem("color-theme") === "dark" || (!("color-theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches),
+      initLight: !(localStorage.getItem("color-theme") === "dark" || (!("color-theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches)),
+      toDarkAnimate: false,
+      toLightAnimate: false,
+
       toggle() {
         this.on = !this.on;
+
+        this.toDarkAnimate = this.animate && this.on && this.initLight;
+        this.toLightAnimate = this.animate && !this.on && this.initDark;
+
         if (this.on) {
           document.documentElement.classList.add("dark");
           localStorage.setItem("color-theme", "dark");
@@ -33,7 +49,38 @@
           document.documentElement.classList.remove("dark");
           localStorage.setItem("color-theme", "light");
         }
+
       },
     });
+
+    Alpine.store('bgImg', {
+      on: "{{ .Site.Params.background.enable }}" === 'true',
+      light: "{{ .Site.Params.background.lightImg }}",
+      dark: "{{ .Site.Params.background.darkImg }}",
+      bgImg: Alpine.store('darkMode').on ? this.dark : this.light, // 初始值
+
+      init() {
+        console.log('bg enable: ' + this.on)
+        if (!this.on) {
+          this.light = "";
+          this.dark = "";
+        }
+        this.updateBgImg();
+        // 监听 darkMode 的变化
+        Alpine.effect(() => {
+          this.updateBgImg();
+        });
+      },
+
+      updateBgImg() {
+        if (this.on) {
+          const darkModeOn = Alpine.store('darkMode').on;
+          this.bgImg = darkModeOn ? this.dark : this.light;
+        } else {
+          this.bgImg = "";
+        }
+      }
+    });
+
   });
 </script>


### PR DESCRIPTION
Transition animation is invalid when switching between darker, lighter color modes after initially or clearing the cache to reload the page. Fixed this bug by rewriting the switching logic and preloading the background image.