### PR TITLE
Fix the refresh flicker issue in dark mode.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -42,6 +42,7 @@
 
   <body
     x-ref="body"
+    x-cloak
     x-data="{ 
       shrink: window.scrollY > 10 ? true : false,
       scrollY: 0,


### PR DESCRIPTION
**问题：** 在dark mode中刷新页面会闪烁

```html
<body
x-ref="body"
x-cloak
x-data="{ }">
</body>
```
通过修改更新 body 标签，添加 x-clock 属性
x-cloak 会在 Alpine.js 初始化完成之前隐藏元素。

---

**Problem:** Refreshing the page in dark mode causes a flicker.
﻿
**Code Snippet:**
﻿
```html
<body
x-ref="body"
x-cloak
x-data="{ }">
</body>
```
﻿
**Solution:**
﻿
By modifying the `<body>` tag and adding the `x-cloak` attribute, the flicker issue can be resolved.
﻿
**Explanation:**
﻿
*   **x-cloak:** This attribute, used with Alpine.js, hides the element until Alpine.js has fully initialized. This prevents the unstyled content from being displayed briefly during page load, which is the cause of the flicker in dark mode.
﻿
﻿